### PR TITLE
Fix tritsteel stuff

### DIFF
--- a/Resources/Locale/en-US/materials/materials.ftl
+++ b/Resources/Locale/en-US/materials/materials.ftl
@@ -6,7 +6,7 @@ materials-reinforced-plasma-glass = reinforced plasma glass
 
 # Metals
 materials-steel = steel
-materials-tritsteel = tritium steel
+materials-tritsteel = tritsteel
 materials-gold = gold
 materials-silver = silver
 materials-plasteel = plasteel

--- a/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Entities/Objects/Materials/Sheets/metal.yml
@@ -232,7 +232,7 @@
 
 - type: entity
   parent: SheetMetalBase
-  id: tritsteel
+  id: SheetTritSteel
   name: tritsteel
   suffix: Full
   components:
@@ -241,7 +241,7 @@
     materialComposition:
       tritsteel: 100
   - type: Stack
-    stackType: tritsteel
+    stackType: TritSteel
     baseLayer: base
     layerStates:
     - tritsteel
@@ -259,7 +259,7 @@
     outputs:
     - Plating
   - type: Extractable
-    grindableSolutionName: tritsteel
+    grindableSolutionName: TritSteel
   - type: SolutionContainerManager
     solutions:
       tritsteel:
@@ -270,27 +270,28 @@
           Quantity: 8
         - ReagentId: Carbon
           Quantity: 1
+        canReact: false
     
 - type: entity
-  parent: tritsteel
-  id: tritsteel10
+  parent: SheetTritSteel
+  id: SheetTritSteel10
   name: tritsteel
   suffix: 10
   components:
   - type: Sprite
     state: tritsteel
   - type: Stack
-    stackType: tritsteel
+    stackType: TritSteel
     count: 10
 
 - type: entity
-  parent: tritsteel
-  id: tritsteel1
+  parent: SheetTritSteel
+  id: SheetTritSteel1
   name: tritsteel
   suffix: Single
   components:
   - type: Sprite
     state: tritsteel
   - type: Stack
-    stackType: tritsteel
+    stackType: TritSteel
     count: 1

--- a/Resources/Prototypes/Reagents/Materials/metals.yml
+++ b/Resources/Prototypes/Reagents/Materials/metals.yml
@@ -40,8 +40,8 @@
   price: 0.28 # 1-1 mix of plasma and steel.
   
 - type: material
-  id: tritsteel
-  stackEntity: tritsteel1
+  id: TritSteel
+  stackEntity: SheetTritSteel1
   name: materials-tritsteel
   icon: { sprite: Objects/Materials/Sheets/metal.rsi, state: tritsteel }
   color: "#66FF33"

--- a/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_binary.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/utilities/atmos_binary.yml
@@ -54,7 +54,7 @@
     
     - to: radiatorUpgraded
       steps:
-      - material: tritsteel
+      - material: TritSteel
         amount: 2
         doAfter: 1
 
@@ -199,7 +199,7 @@
         anchored: false
       completed:
       - !type:SpawnPrototype
-        prototype: tritsteel
+        prototype: SheetTritSteel1
         amount: 2
       - !type:DeleteEntity
       steps:

--- a/Resources/Prototypes/Recipes/Reactions/chemicals.yml
+++ b/Resources/Prototypes/Recipes/Reactions/chemicals.yml
@@ -503,14 +503,14 @@
     Tazinide: 1
 
 - type: reaction
-  id: tritsteel
+  id: TritSteel
   reactants:
     Iron:
-      amount: 5
+      amount: 4
     Carbon:
       amount: 2
     Tritium:
-      amount: 5
+      amount: 4
   effects:
     - !type:CreateEntityReactionEffect
-      entity: tritsteel
+      entity: TritSteel

--- a/Resources/Prototypes/Stacks/Materials/Sheets/metal.yml
+++ b/Resources/Prototypes/Stacks/Materials/Sheets/metal.yml
@@ -21,3 +21,11 @@
   spawn: SheetBrass1
   maxCount: 30
   itemSize: 1
+
+- type: stack
+  id: TritSteel
+  name: tritsteel
+  icon: {  sprite: /Textures/Objects/Materials/Sheets/metal.rsi, state: tritsteel }
+  spawn: SheetTritSteel1
+  maxCount: 30
+  itemSize: 1


### PR DESCRIPTION
## About the PR
Tritsteel now works and can be used to make the upgraded radiator

## Technical details
All traces of TritSteel were converted into specifically `TritSteel` except in cases where it would be normal "no caps" naming conventions. Other than that, just prototype work.